### PR TITLE
DTSPO-440 - Fix query and import modules 

### DIFF
--- a/terraform/log-alert.tf
+++ b/terraform/log-alert.tf
@@ -17,7 +17,7 @@ resource "azurerm_monitor_scheduled_query_rules_alert" "disabled_users_alert" {
   enabled        = true
 
   query       = <<-QUERY
-  requests
+  AuditLogs
     | where OperationName  == "Disable account" 
     | project TargetResources[0].userPrincipalName
   QUERY

--- a/terraform/runbook.tf
+++ b/terraform/runbook.tf
@@ -22,6 +22,28 @@ resource "azurerm_automation_runbook" "github_membership_runbook" {
   runbook_type            = "PowerShell"
 
   publish_content_link {
-    uri = "https://raw.githubusercontent.com/hmcts/azure-automation-runbooks/master/runbooks/Get-AzureVMTutorial.ps1"
+    uri = "https://raw.githubusercontent.com/hmcts/azure-automation-runbooks/DTSPO-440-create-offboarding-runbook/runbooks/Remove-User.ps1"
   }
+}
+
+resource "azurerm_automation_module" "az_accounts_module" {
+  name                    = "Az.Accounts"
+  resource_group_name     = azurerm_resource_group.rg_github_membership.name
+  automation_account_name = azurerm_automation_account.github_membership_automation.name
+
+  module_link {
+    uri = "https://devopsgallerystorage.blob.core.windows.net/packages/az.accounts.2.2.5.nupkg"
+  }
+}
+
+resource "azurerm_automation_module" "az_keyvault_module" {
+  name                    = "Az.KeyVault"
+  resource_group_name     = azurerm_resource_group.rg_github_membership.name
+  automation_account_name = azurerm_automation_account.github_membership_automation.name
+
+  module_link {
+    uri = "https://devopsgallerystorage.blob.core.windows.net/packages/az.keyvault.4.0.2-preview.nupkg"
+  }
+  # This module cannot be imported unless the Accounts Module has been imported first
+  depends_on = [ azurerm_automation_module.az_accounts_module ]
 }

--- a/terraform/runbook.tf
+++ b/terraform/runbook.tf
@@ -22,7 +22,7 @@ resource "azurerm_automation_runbook" "github_membership_runbook" {
   runbook_type            = "PowerShell"
 
   publish_content_link {
-    uri = "https://raw.githubusercontent.com/hmcts/azure-automation-runbooks/DTSPO-440-create-offboarding-runbook/runbooks/Remove-User.ps1"
+    uri = "https://raw.githubusercontent.com/hmcts/azure-automation-runbooks/DTSPO-440-create-offboarding-runbook/runbooks/Remove-UserGitHubAccess.ps1"
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -15,3 +15,4 @@ variable "runbook_name" {
 locals {
   webhook_uri = "https://${var.runbook_name}.webhook.uks.azure-automation.net/webhooks?token=${random_string.token1.result}%2b${random_string.token2.result}%3d"
 }
+


### PR DESCRIPTION
### Change description ###
- Tweak alert query to use AuditLogs
- Change runbook uri to the test runbook ( needs to be repointed to main once its merged into main)
- import az modules that the runbook uses

I was using a list variable for the modules with a for_each and for loop but couldn't see a way of getting the depends_on to work with a condition. Any work-arounds welcome! 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
